### PR TITLE
Add code to see if Registry key value exists.

### DIFF
--- a/hsp_registry-helper/Registry Key Manipulation Stuff/regkeyvalue_Verify.vb
+++ b/hsp_registry-helper/Registry Key Manipulation Stuff/regkeyvalue_Verify.vb
@@ -37,8 +37,15 @@ Public Class regkeyvalue_Verify
 
     Public Shared Sub runVerification()
 
-        If My.Computer.Registry.GetValue("HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer", "SettingsPageVisibility", Nothing) Is Nothing Then
+        Dim tempVal As String = My.Computer.Registry.GetValue("HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer", "SettingsPageVisibility", Nothing)
+
+        If tempVal Is Nothing Then
             ' If the registry key value doesn't exist, tell the user.
+            MessageBox.Show("Registry key value does not exist.", "Verify key value")
+
+        Else
+            ' If the registry key value does exist, tell the user what it is.
+            MessageBox.Show()
 
         End If
 

--- a/hsp_registry-helper/Registry Key Manipulation Stuff/regkeyvalue_Verify.vb
+++ b/hsp_registry-helper/Registry Key Manipulation Stuff/regkeyvalue_Verify.vb
@@ -33,7 +33,7 @@ Public Class regkeyvalue_Verify
     ' retrieve the proper key value from the Registry if it exists.
 
     ' I'm using a solution based on this thread:
-    ' https://stackoverflow.com/questions/9206172/delete-key-from-registery
+    ' https://social.msdn.microsoft.com/Forums/en-US/7272f987-bfb5-4bac-a72c-dfde5745832f/how-to-use-add-read-change-delete-registry-keys-with-vbnet?forum=Vsexpressvb
 
     Public Shared Sub runVerification()
 

--- a/hsp_registry-helper/Registry Key Manipulation Stuff/regkeyvalue_Verify.vb
+++ b/hsp_registry-helper/Registry Key Manipulation Stuff/regkeyvalue_Verify.vb
@@ -29,5 +29,8 @@
 
 
 Public Class regkeyvalue_Verify
+    ' If the user chooses to /verify the current Registry key value,
+    ' retrieve the proper key value from the Registry if it exists.
+
 
 End Class

--- a/hsp_registry-helper/Registry Key Manipulation Stuff/regkeyvalue_Verify.vb
+++ b/hsp_registry-helper/Registry Key Manipulation Stuff/regkeyvalue_Verify.vb
@@ -45,7 +45,7 @@ Public Class regkeyvalue_Verify
 
         Else
             ' If the registry key value does exist, tell the user what it is.
-            MessageBox.Show()
+            MessageBox.Show("Registry key value exists." & vbCrLf & "Data:" & vbCrLf & tempVal)
 
         End If
 

--- a/hsp_registry-helper/Registry Key Manipulation Stuff/regkeyvalue_Verify.vb
+++ b/hsp_registry-helper/Registry Key Manipulation Stuff/regkeyvalue_Verify.vb
@@ -32,5 +32,12 @@ Public Class regkeyvalue_Verify
     ' If the user chooses to /verify the current Registry key value,
     ' retrieve the proper key value from the Registry if it exists.
 
+    ' I'm using a solution based on this thread:
+    ' https://stackoverflow.com/questions/9206172/delete-key-from-registery
+
+    Public Shared Sub runVerification()
+
+    End Sub
+
 
 End Class

--- a/hsp_registry-helper/Registry Key Manipulation Stuff/regkeyvalue_Verify.vb
+++ b/hsp_registry-helper/Registry Key Manipulation Stuff/regkeyvalue_Verify.vb
@@ -1,0 +1,33 @@
+﻿'HideSettingsPages Registry Helper - Used to apply the Registry
+'key value chosen in HideSettingsPages. Can also apply/remove key value via arguments
+'and show the current value in the Registry.
+'This key value will hide or show pages in the Windows 10 Settings app on the Creators Update and newer.
+'Copyright (C) 2017  Drew Naylor
+'Microsoft Windows and all related words are copyright
+'and trademark Microsoft Corporation.
+'Any other companies mentioned own their respective copyrights/trademarks.
+'(Note that the copyright years include the years left out by the hyphen.)
+'
+'This file is part of HideSettingsPages Registry Helper
+'which is used by HideSettingsPages
+'(Program is also known as "hsp_registry-helper.")
+'
+'hsp_registry-helper is free software: you can redistribute it and/or modify
+'it under the terms of the GNU General Public License as published by
+'the Free Software Foundation, either version 3 of the License, or
+'(at your option) any later version.
+'
+'hsp_registry-helper is distributed in the hope that it will be useful,
+'but WITHOUT ANY WARRANTY; without even the implied warranty of
+'MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+'GNU General Public License for more details.
+'
+'You should have received a copy of the GNU General Public License
+'along with hsp_registry-helper.  If not, see <http://www.gnu.org/licenses/>.
+
+
+
+
+Public Class regkeyvalue_Verify
+
+End Class

--- a/hsp_registry-helper/Registry Key Manipulation Stuff/regkeyvalue_Verify.vb
+++ b/hsp_registry-helper/Registry Key Manipulation Stuff/regkeyvalue_Verify.vb
@@ -37,6 +37,11 @@ Public Class regkeyvalue_Verify
 
     Public Shared Sub runVerification()
 
+        If My.Computer.Registry.GetValue("HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer", "SettingsPageVisibility", Nothing) Is Nothing Then
+            ' If the registry key value doesn't exist, tell the user.
+
+        End If
+
     End Sub
 
 

--- a/hsp_registry-helper/Registry Key Manipulation Stuff/regkeyvalue_Verify.vb
+++ b/hsp_registry-helper/Registry Key Manipulation Stuff/regkeyvalue_Verify.vb
@@ -45,7 +45,7 @@ Public Class regkeyvalue_Verify
 
         Else
             ' If the registry key value does exist, tell the user what it is.
-            MessageBox.Show("Registry key value exists." & vbCrLf & "Data:" & vbCrLf & tempVal)
+            MessageBox.Show("Registry key value exists." & vbCrLf & vbCrLf & vbCrLf & "Data:" & vbCrLf & vbCrLf & tempVal, "Verify key value")
 
         End If
 

--- a/hsp_registry-helper/Registry Key Manipulation Stuff/regkeyvalue_Verify.vb
+++ b/hsp_registry-helper/Registry Key Manipulation Stuff/regkeyvalue_Verify.vb
@@ -1,6 +1,6 @@
 ﻿'HideSettingsPages Registry Helper - Used to apply the Registry
 'key value chosen in HideSettingsPages. Can also apply/remove key value via arguments
-'and show the current value in the Registry.
+'and show the current value in the Registry, also with arguments.
 'This key value will hide or show pages in the Windows 10 Settings app on the Creators Update and newer.
 'Copyright (C) 2017  Drew Naylor
 'Microsoft Windows and all related words are copyright

--- a/hsp_registry-helper/argsOutput.vb
+++ b/hsp_registry-helper/argsOutput.vb
@@ -1,5 +1,6 @@
 ﻿'HideSettingsPages Registry Helper - Used to apply the Registry
-'key value chosen in HideSettingsPages. Can also apply/remove key value via arguments.
+'key value chosen in HideSettingsPages. Can also apply/remove key value via arguments
+'and show the current value in the Registry.
 'This key value will hide or show pages in the Windows 10 Settings app on the Creators Update and newer.
 'Copyright (C) 2017  Drew Naylor
 'Microsoft Windows and all related words are copyright

--- a/hsp_registry-helper/argsOutput.vb
+++ b/hsp_registry-helper/argsOutput.vb
@@ -72,5 +72,9 @@ Public Class argsOutput
 
         MessageBox.Show("This is the full Registry key value.")
         MessageBox.Show("Stop.")
+
+        If actionToTake = "/verify" Then
+            regkeyvalue_Verify.runVerification()
+        End If
     End Sub
 End Class

--- a/hsp_registry-helper/argsOutput.vb
+++ b/hsp_registry-helper/argsOutput.vb
@@ -1,6 +1,6 @@
 ﻿'HideSettingsPages Registry Helper - Used to apply the Registry
 'key value chosen in HideSettingsPages. Can also apply/remove key value via arguments
-'and show the current value in the Registry.
+'and show the current value in the Registry, also with arguments.
 'This key value will hide or show pages in the Windows 10 Settings app on the Creators Update and newer.
 'Copyright (C) 2017  Drew Naylor
 'Microsoft Windows and all related words are copyright
@@ -39,7 +39,8 @@ Public Class argsOutput
         Console.WriteLine("Description:")
         Console.WriteLine("")
         Console.WriteLine(vbTab & "Applies the Registry key value chosen in HideSettingsPages.")
-        Console.WriteLine(vbTab & "Can also apply/remove key value via arguments.")
+        Console.WriteLine(vbTab & "Can also apply/remove key value via arguments and show the")
+        Console.WriteLine(vbTab & "current Registry key value in the Registry, also with arguments.")
         Console.WriteLine(vbTab & "This key value will hide or show pages in the Windows 10 Settings app")
         Console.WriteLine(vbTab & "on the Creators Update and newer.")
         Console.WriteLine("")

--- a/hsp_registry-helper/hsp_registry-helper.vbproj
+++ b/hsp_registry-helper/hsp_registry-helper.vbproj
@@ -107,6 +107,7 @@
       <DesignTimeSharedInput>True</DesignTimeSharedInput>
     </Compile>
     <Compile Include="argsOutput.vb" />
+    <Compile Include="Registry Key Manipulation Stuff\regkeyvalue_Verify.vb" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="My Project\Resources.resx">

--- a/hsp_registry-helper/hsp_registry_helper_main.vb
+++ b/hsp_registry-helper/hsp_registry_helper_main.vb
@@ -1,5 +1,6 @@
 ﻿'HideSettingsPages Registry Helper - Used to apply the Registry
-'key value chosen in HideSettingsPages. Can also apply/remove key value via arguments.
+'key value chosen in HideSettingsPages. Can also apply/remove key value via arguments
+'and show the current value in the Registry.
 'This key value will hide or show pages in the Windows 10 Settings app on the Creators Update and newer.
 'Copyright (C) 2017  Drew Naylor
 'Microsoft Windows and all related words are copyright

--- a/hsp_registry-helper/hsp_registry_helper_main.vb
+++ b/hsp_registry-helper/hsp_registry_helper_main.vb
@@ -1,6 +1,6 @@
 ﻿'HideSettingsPages Registry Helper - Used to apply the Registry
 'key value chosen in HideSettingsPages. Can also apply/remove key value via arguments
-'and show the current value in the Registry.
+'and show the current value in the Registry, also with arguments.
 'This key value will hide or show pages in the Windows 10 Settings app on the Creators Update and newer.
 'Copyright (C) 2017  Drew Naylor
 'Microsoft Windows and all related words are copyright


### PR DESCRIPTION
Even though it didn't take very long to implement, by allowing the user to see what their current key value is, they can know what pages are hidden or shown. This can also be used in other parts of the registry helper app to tell the user about the current key when it gets applied.