### PR TITLE
Allow undoing all SettingsPageVisibility changes.

### DIFF
--- a/HideSettingsPages/aaformMainWindow.vb
+++ b/HideSettingsPages/aaformMainWindow.vb
@@ -121,7 +121,7 @@ Public Class aaformMainWindow
         Dim proc As New ProcessStartInfo
         proc.FileName = My.Application.Info.DirectoryPath & "\hsp_registry-helper.exe"
         proc.Arguments = "/undo "
-        'proc.Verb = "runas"
+        proc.Verb = "runas"
         Process.Start(proc)
     End Sub
 #End Region

--- a/hsp_registry-helper/Registry Key Manipulation Stuff/regkeyvalue_Undo.vb
+++ b/hsp_registry-helper/Registry Key Manipulation Stuff/regkeyvalue_Undo.vb
@@ -31,6 +31,9 @@ Public Class regkeyvalue_Undo
     ' If the user chooses to /undo the Registry key value,
     ' delete the proper key value if it exists.
 
+    ' I'm using a solution based on this thread:
+    ' https://social.msdn.microsoft.com/Forums/en-US/7272f987-bfb5-4bac-a72c-dfde5745832f/how-to-use-add-read-change-delete-registry-keys-with-vbnet?forum=Vsexpressvb
+
     Friend Shared Sub runDeletion()
         MessageBox.Show("/undo was chosen.")
     End Sub

--- a/hsp_registry-helper/Registry Key Manipulation Stuff/regkeyvalue_Undo.vb
+++ b/hsp_registry-helper/Registry Key Manipulation Stuff/regkeyvalue_Undo.vb
@@ -32,7 +32,7 @@ Public Class regkeyvalue_Undo
     ' delete the proper key value if it exists.
 
     Friend Shared Sub runDeletion()
-
+        MessageBox.Show("/undo was chosen.")
     End Sub
 
 End Class

--- a/hsp_registry-helper/Registry Key Manipulation Stuff/regkeyvalue_Undo.vb
+++ b/hsp_registry-helper/Registry Key Manipulation Stuff/regkeyvalue_Undo.vb
@@ -52,9 +52,9 @@ Public Class regkeyvalue_Undo
             ' https://social.msdn.microsoft.com/Forums/en-US/7272f987-bfb5-4bac-a72c-dfde5745832f/how-to-use-add-read-change-delete-registry-keys-with-vbnet?forum=Vsexpressvb
 
             Try
-                Dim deleteFrom As RegistryKey = My.Computer.Registry.LocalMachine.OpenSubKey("\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer", True)
-                My.Computer.Registry.LocalMachine.DeleteValue(tempVal)
-            Catch ex As Security.SecurityException
+                Dim deleteFrom As RegistryKey = My.Computer.Registry.LocalMachine.CreateSubKey("SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer", True)
+                deleteFrom.DeleteValue("SettingsPageVisibility")
+            Catch ex As UnauthorizedAccessException
                 ' Tell the user if they're not elevated.
 
                 MessageBox.Show("The Registry key value cannot be deleted because the app isn't running as Administrator. Please elevate and try again.")

--- a/hsp_registry-helper/Registry Key Manipulation Stuff/regkeyvalue_Undo.vb
+++ b/hsp_registry-helper/Registry Key Manipulation Stuff/regkeyvalue_Undo.vb
@@ -26,9 +26,11 @@
 'along with hsp_registry-helper.  If not, see <http://www.gnu.org/licenses/>.
 
 
-' System.Security.Principal is used to see
-' if the user is admin or not.
-Imports System.Security.Principal
+
+
+' Microsoft.Win32 is used for registry stuff.
+Imports Microsoft.Win32
+
 Public Class regkeyvalue_Undo
     ' If the user chooses to /undo the Registry key value,
     ' delete the proper key value if it exists.
@@ -42,22 +44,23 @@ Public Class regkeyvalue_Undo
 
         ' First see if there's a key value to delete.
         If tempVal IsNot Nothing Then
-            ' Next, if the user is admin, delete the key value.
-            ' Code based on this: https://stackoverflow.com/a/6099113
+            ' Next, if the user is admin, delete the key value. Using a try/catch because I don't know
+            ' how to do it properly. Can't find any examples in VB.
 
-            Dim currentIdentity = WindowsIdentity.GetCurrent
-            Dim principal = New WindowsPrincipal(currentIdentity)
-            Dim isElevated As Boolean = principal.IsInRole(WindowsBuiltInRole.PowerUser)
+            ' Now we can delete the key value.
+            ' Code from:
+            ' https://social.msdn.microsoft.com/Forums/en-US/7272f987-bfb5-4bac-a72c-dfde5745832f/how-to-use-add-read-change-delete-registry-keys-with-vbnet?forum=Vsexpressvb
 
-            ' Check current elevation status.
-            If isElevated = True Then
-                ' Now we can delete the key value.
-                ' Code from:
-                ' https://social.msdn.microsoft.com/Forums/en-US/7272f987-bfb5-4bac-a72c-dfde5745832f/how-to-use-add-read-change-delete-registry-keys-with-vbnet?forum=Vsexpressvb
-
+            Try
+                Dim deleteFrom As RegistryKey = My.Computer.Registry.LocalMachine.OpenSubKey("\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer", True)
                 My.Computer.Registry.LocalMachine.DeleteValue(tempVal)
+            Catch ex As Security.SecurityException
+                ' Tell the user if they're not elevated.
 
-            End If
+                MessageBox.Show("The Registry key value cannot be deleted because the app isn't running as Administrator. Please elevate and try again.")
+            End Try
+
+
         End If
 
     End Sub

--- a/hsp_registry-helper/Registry Key Manipulation Stuff/regkeyvalue_Undo.vb
+++ b/hsp_registry-helper/Registry Key Manipulation Stuff/regkeyvalue_Undo.vb
@@ -26,7 +26,9 @@
 'along with hsp_registry-helper.  If not, see <http://www.gnu.org/licenses/>.
 
 
-
+' System.Security.Principal is used to see
+' if the user is admin or not.
+Imports System.Security.Principal
 Public Class regkeyvalue_Undo
     ' If the user chooses to /undo the Registry key value,
     ' delete the proper key value if it exists.
@@ -36,6 +38,14 @@ Public Class regkeyvalue_Undo
 
     Friend Shared Sub runDeletion()
         MessageBox.Show("/undo was chosen.")
+        Dim tempVal As String = My.Computer.Registry.GetValue("HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer", "SettingsPageVisibility", Nothing)
+
+        ' First see if there's a key value to delete.
+        If tempVal IsNot Nothing Then
+            ' Next, if the user is admin, delete the key value.
+            ' Code based on this: https://stackoverflow.com/a/6099113
+        End If
+
     End Sub
 
 End Class

--- a/hsp_registry-helper/Registry Key Manipulation Stuff/regkeyvalue_Undo.vb
+++ b/hsp_registry-helper/Registry Key Manipulation Stuff/regkeyvalue_Undo.vb
@@ -44,6 +44,10 @@ Public Class regkeyvalue_Undo
         If tempVal IsNot Nothing Then
             ' Next, if the user is admin, delete the key value.
             ' Code based on this: https://stackoverflow.com/a/6099113
+
+            Dim currentIdentity = WindowsIdentity.GetCurrent
+            Dim principal = New WindowsPrincipal(currentIdentity)
+            Dim isElevated As Boolean = principal.IsInRole(WindowsBuiltInRole.Administrator)
         End If
 
     End Sub

--- a/hsp_registry-helper/Registry Key Manipulation Stuff/regkeyvalue_Undo.vb
+++ b/hsp_registry-helper/Registry Key Manipulation Stuff/regkeyvalue_Undo.vb
@@ -47,11 +47,15 @@ Public Class regkeyvalue_Undo
 
             Dim currentIdentity = WindowsIdentity.GetCurrent
             Dim principal = New WindowsPrincipal(currentIdentity)
-            Dim isElevated As Boolean = principal.IsInRole(WindowsBuiltInRole.Administrator)
+            Dim isElevated As Boolean = principal.IsInRole(WindowsBuiltInRole.PowerUser)
 
             ' Check current elevation status.
             If isElevated = True Then
                 ' Now we can delete the key value.
+                ' Code from:
+                ' https://social.msdn.microsoft.com/Forums/en-US/7272f987-bfb5-4bac-a72c-dfde5745832f/how-to-use-add-read-change-delete-registry-keys-with-vbnet?forum=Vsexpressvb
+
+                My.Computer.Registry.LocalMachine.DeleteValue(tempVal)
 
             End If
         End If

--- a/hsp_registry-helper/Registry Key Manipulation Stuff/regkeyvalue_Undo.vb
+++ b/hsp_registry-helper/Registry Key Manipulation Stuff/regkeyvalue_Undo.vb
@@ -1,0 +1,35 @@
+﻿'HideSettingsPages Registry Helper - Used to apply the Registry
+'key value chosen in HideSettingsPages. Can also apply/remove key value via arguments
+'and show the current value in the Registry, also with arguments.
+'This key value will hide or show pages in the Windows 10 Settings app on the Creators Update and newer.
+'Copyright (C) 2017  Drew Naylor
+'Microsoft Windows and all related words are copyright
+'and trademark Microsoft Corporation.
+'Any other companies mentioned own their respective copyrights/trademarks.
+'(Note that the copyright years include the years left out by the hyphen.)
+'
+'This file is part of HideSettingsPages Registry Helper
+'which is used by HideSettingsPages
+'(Program is also known as "hsp_registry-helper.")
+'
+'hsp_registry-helper is free software: you can redistribute it and/or modify
+'it under the terms of the GNU General Public License as published by
+'the Free Software Foundation, either version 3 of the License, or
+'(at your option) any later version.
+'
+'hsp_registry-helper is distributed in the hope that it will be useful,
+'but WITHOUT ANY WARRANTY; without even the implied warranty of
+'MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+'GNU General Public License for more details.
+'
+'You should have received a copy of the GNU General Public License
+'along with hsp_registry-helper.  If not, see <http://www.gnu.org/licenses/>.
+
+
+
+Public Class regkeyvalue_Undo
+    ' If the user chooses to /undo the Registry key value,
+    ' delete the proper key value if it exists.
+
+
+End Class

--- a/hsp_registry-helper/Registry Key Manipulation Stuff/regkeyvalue_Undo.vb
+++ b/hsp_registry-helper/Registry Key Manipulation Stuff/regkeyvalue_Undo.vb
@@ -52,17 +52,13 @@ Public Class regkeyvalue_Undo
             ' https://social.msdn.microsoft.com/Forums/en-US/7272f987-bfb5-4bac-a72c-dfde5745832f/how-to-use-add-read-change-delete-registry-keys-with-vbnet?forum=Vsexpressvb
 
             Try
-                Dim deleteFrom As RegistryKey = My.Computer.Registry.LocalMachine.CreateSubKey("SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer", True)
+                Dim deleteFrom As RegistryKey = My.Computer.Registry.LocalMachine.OpenSubKey("SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer", True)
                 deleteFrom.DeleteValue("SettingsPageVisibility")
-            Catch ex As UnauthorizedAccessException
+            Catch ex As Security.SecurityException
                 ' Tell the user if they're not elevated.
 
                 MessageBox.Show("The Registry key value cannot be deleted because the app isn't running as Administrator. Please elevate and try again.")
             End Try
-
-
         End If
-
     End Sub
-
 End Class

--- a/hsp_registry-helper/Registry Key Manipulation Stuff/regkeyvalue_Undo.vb
+++ b/hsp_registry-helper/Registry Key Manipulation Stuff/regkeyvalue_Undo.vb
@@ -31,5 +31,8 @@ Public Class regkeyvalue_Undo
     ' If the user chooses to /undo the Registry key value,
     ' delete the proper key value if it exists.
 
+    Friend Shared Sub runDeletion()
+
+    End Sub
 
 End Class

--- a/hsp_registry-helper/Registry Key Manipulation Stuff/regkeyvalue_Undo.vb
+++ b/hsp_registry-helper/Registry Key Manipulation Stuff/regkeyvalue_Undo.vb
@@ -48,6 +48,12 @@ Public Class regkeyvalue_Undo
             Dim currentIdentity = WindowsIdentity.GetCurrent
             Dim principal = New WindowsPrincipal(currentIdentity)
             Dim isElevated As Boolean = principal.IsInRole(WindowsBuiltInRole.Administrator)
+
+            ' Check current elevation status.
+            If isElevated = True Then
+                ' Now we can delete the key value.
+
+            End If
         End If
 
     End Sub

--- a/hsp_registry-helper/argsOutput.vb
+++ b/hsp_registry-helper/argsOutput.vb
@@ -75,6 +75,8 @@ Public Class argsOutput
 
         If actionToTake = "/verify" Then
             regkeyvalue_Verify.runVerification()
+        ElseIf actionToTake = "/undo" Then
+            regkeyvalue_Undo.runDeletion
         End If
     End Sub
 End Class

--- a/hsp_registry-helper/hsp_registry-helper.vbproj
+++ b/hsp_registry-helper/hsp_registry-helper.vbproj
@@ -107,6 +107,7 @@
       <DesignTimeSharedInput>True</DesignTimeSharedInput>
     </Compile>
     <Compile Include="argsOutput.vb" />
+    <Compile Include="Registry Key Manipulation Stuff\regkeyvalue_Undo.vb" />
     <Compile Include="Registry Key Manipulation Stuff\regkeyvalue_Verify.vb" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Now hsp_registry-helper.exe can delete the SettingsPageVisibility Registry key value automatically if it's running as admin. If not, it'll just complain and ask to be run as admin and have the user try again.

"Automatically" meaning, "if the user wants to."