### PR TITLE
Allow adding value to Registry key.

### DIFF
--- a/HideSettingsPages/aaformMainWindow.Designer.vb
+++ b/HideSettingsPages/aaformMainWindow.Designer.vb
@@ -128,7 +128,7 @@ Partial Class aaformMainWindow
         Me.panelScrollablePageList.Controls.Add(Me.labelChoosePages)
         Me.panelScrollablePageList.Dock = System.Windows.Forms.DockStyle.Fill
         Me.panelScrollablePageList.Location = New System.Drawing.Point(3, 16)
-        Me.panelScrollablePageList.Margin = New System.Windows.Forms.Padding(2, 2, 2, 2)
+        Me.panelScrollablePageList.Margin = New System.Windows.Forms.Padding(2)
         Me.panelScrollablePageList.Name = "panelScrollablePageList"
         Me.panelScrollablePageList.Size = New System.Drawing.Size(317, 420)
         Me.panelScrollablePageList.TabIndex = 13
@@ -138,7 +138,7 @@ Partial Class aaformMainWindow
         Me.checkedlistboxPageList.CheckOnClick = True
         Me.checkedlistboxPageList.Items.AddRange(New Object() {"about", "activation", "appsfeatures", "appsforwebsites", "autoplay", "backup", "batterysaver", "batterysaver-usagedetails", "bluetooth", "camera", "colors", "connecteddevices", "cortana", "cortana-moredetails", "cortana-permissions", "crossdevice", "datausage", "dateandtime", "defaultapps", "developers", "deviceencryption", "display", "easeofaccess-closedcaptioning", "easeofaccess-highcontrast", "easeofaccess-keyboard", "easeofaccess-magnifier", "easeofaccess-mouse", "easeofaccess-narrator", "easeofaccess-otheroptions", "emailandaccounts", "extras", "findmydevice", "gaming-broadcasting", "gaming-gamebar", "gaming-gamedvr", "gaming-gamemode", "holographic", "holographic-audio", "lockscreen", "maps", "mousetouchpad", "multitasking", "network-airplanemode", "network-cellular", "network-dialup", "network-directaccess", "network-ethernet", "network-mobilehotspot", "network-proxy", "network-status", "network-vpn", "network-wifi", "network-wifisettings", "nfctransactions", "notifications", "optionalfeatures", "otherusers", "pen", "personalization-background", "personalization-start", "powersleep", "printers", "privacy", "privacy-accountinfo", "privacy-appdiagnostics", "privacy-backgroundapps", "privacy-calendar", "privacy-callhistory", "privacy-contacts", "privacy-customdevices", "privacy-email", "privacy-feedback", "privacy-location", "privacy-messaging", "privacy-microphone", "privacy-motion", "privacy-notifications", "privacy-radios", "privacy-speechtyping", "privacy-tasks", "privacy-webcam", "project", "recovery", "regionlanguage", "signinoptions", "speech", "storagesense", "sync", "tabletmode", "taskbar", "themes", "troubleshoot", "typing", "usb", "windowsdefender", "windowsinsider", "windowsupdate", "windowsupdate-action", "windowsupdate-history", "windowsupdate-options", "windowsupdate-restartoptions", "workplace", "yourinfo"})
         Me.checkedlistboxPageList.Location = New System.Drawing.Point(3, 22)
-        Me.checkedlistboxPageList.Margin = New System.Windows.Forms.Padding(2, 2, 2, 2)
+        Me.checkedlistboxPageList.Margin = New System.Windows.Forms.Padding(2)
         Me.checkedlistboxPageList.Name = "checkedlistboxPageList"
         Me.checkedlistboxPageList.Size = New System.Drawing.Size(311, 394)
         Me.checkedlistboxPageList.TabIndex = 17
@@ -190,7 +190,7 @@ Partial Class aaformMainWindow
         Me.panelApplyUndoExit.Controls.Add(Me.buttonApplyChanges)
         Me.panelApplyUndoExit.Controls.Add(Me.buttonUndoChanges)
         Me.panelApplyUndoExit.Location = New System.Drawing.Point(2, 625)
-        Me.panelApplyUndoExit.Margin = New System.Windows.Forms.Padding(2, 2, 2, 2)
+        Me.panelApplyUndoExit.Margin = New System.Windows.Forms.Padding(2)
         Me.panelApplyUndoExit.Name = "panelApplyUndoExit"
         Me.panelApplyUndoExit.Size = New System.Drawing.Size(324, 34)
         Me.panelApplyUndoExit.TabIndex = 4
@@ -291,7 +291,7 @@ Partial Class aaformMainWindow
         Me.Controls.Add(Me.menubarMainWindow)
         Me.Icon = CType(resources.GetObject("$this.Icon"), System.Drawing.Icon)
         Me.MainMenuStrip = Me.menubarMainWindow
-        Me.Margin = New System.Windows.Forms.Padding(2, 2, 2, 2)
+        Me.Margin = New System.Windows.Forms.Padding(2)
         Me.Name = "aaformMainWindow"
         Me.Text = "HideSettingsPages"
         Me.flowlayoutpanelMainWindow.ResumeLayout(False)

--- a/HideSettingsPages/aaformMainWindow.vb
+++ b/HideSettingsPages/aaformMainWindow.vb
@@ -131,7 +131,15 @@ Public Class aaformMainWindow
         proc.FileName = My.Application.Info.DirectoryPath & "\hsp_registry-helper.exe"
         proc.Arguments = "/apply " & registryKeyValueBuilder.stringFullRegistryKeyValue
         proc.Verb = "runas"
-        Process.Start(proc)
+        Try
+            Process.Start(proc)
+            ' We have to catch this exception
+            ' in case the user clicks "No" in the UAC
+            ' dialog. Otherwise, we get an error
+            ' that says that the operation was
+            ' canceled by the user.
+        Catch ex As ComponentModel.Win32Exception
+        End Try
     End Sub
 #End Region
 End Class

--- a/HideSettingsPages/aaformMainWindow.vb
+++ b/HideSettingsPages/aaformMainWindow.vb
@@ -122,7 +122,16 @@ Public Class aaformMainWindow
         proc.FileName = My.Application.Info.DirectoryPath & "\hsp_registry-helper.exe"
         proc.Arguments = "/undo "
         proc.Verb = "runas"
-        Process.Start(proc)
+        Try
+            Process.Start(proc)
+            ' We have to catch this exception
+            ' in case the user clicks "No" in the UAC
+            ' dialog. Otherwise, we get an error
+            ' that says that the operation was
+            ' canceled by the user.
+        Catch ex As ComponentModel.Win32Exception
+        End Try
+
     End Sub
 
     Private Sub buttonApplyChanges_Click(sender As Object, e As EventArgs) Handles buttonApplyChanges.Click

--- a/HideSettingsPages/aaformMainWindow.vb
+++ b/HideSettingsPages/aaformMainWindow.vb
@@ -124,5 +124,14 @@ Public Class aaformMainWindow
         proc.Verb = "runas"
         Process.Start(proc)
     End Sub
+
+    Private Sub buttonApplyChanges_Click(sender As Object, e As EventArgs) Handles buttonApplyChanges.Click
+        ' Tell the registry helper app to apply the key value in the Registry.
+        Dim proc As New ProcessStartInfo
+        proc.FileName = My.Application.Info.DirectoryPath & "\hsp_registry-helper.exe"
+        proc.Arguments = "/apply " & registryKeyValueBuilder.stringFullRegistryKeyValue
+        proc.Verb = "runas"
+        Process.Start(proc)
+    End Sub
 #End Region
 End Class

--- a/hsp_registry-helper/Registry Key Manipulation Stuff/regkeyvalue_Apply.vb
+++ b/hsp_registry-helper/Registry Key Manipulation Stuff/regkeyvalue_Apply.vb
@@ -52,8 +52,10 @@ Public Class regkeyvalue_Apply
             ' https://social.msdn.microsoft.com/Forums/en-US/7272f987-bfb5-4bac-a72c-dfde5745832f/how-to-use-add-read-change-delete-registry-keys-with-vbnet?forum=Vsexpressvb
 
             Try
-                Dim deleteFrom As RegistryKey = My.Computer.Registry.LocalMachine.OpenSubKey("SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer", True)
-                deleteFrom.DeleteValue("SettingsPageVisibility")
+                Dim editFrom As RegistryKey = My.Computer.Registry.LocalMachine.OpenSubKey("SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer", True)
+                ' Now edit the Registry key value.
+                editFrom.SetValue("SettingsPageVisibility", fullKeyValue)
+                editFrom.Close()
             Catch ex As Security.SecurityException
                 ' Tell the user if they're not elevated.
 

--- a/hsp_registry-helper/Registry Key Manipulation Stuff/regkeyvalue_Apply.vb
+++ b/hsp_registry-helper/Registry Key Manipulation Stuff/regkeyvalue_Apply.vb
@@ -1,0 +1,64 @@
+﻿'HideSettingsPages Registry Helper - Used to apply the Registry
+'key value chosen in HideSettingsPages. Can also apply/remove key value via arguments
+'and show the current value in the Registry, also with arguments.
+'This key value will hide or show pages in the Windows 10 Settings app on the Creators Update and newer.
+'Copyright (C) 2017  Drew Naylor
+'Microsoft Windows and all related words are copyright
+'and trademark Microsoft Corporation.
+'Any other companies mentioned own their respective copyrights/trademarks.
+'(Note that the copyright years include the years left out by the hyphen.)
+'
+'This file is part of HideSettingsPages Registry Helper
+'which is used by HideSettingsPages
+'(Program is also known as "hsp_registry-helper.")
+'
+'hsp_registry-helper is free software: you can redistribute it and/or modify
+'it under the terms of the GNU General Public License as published by
+'the Free Software Foundation, either version 3 of the License, or
+'(at your option) any later version.
+'
+'hsp_registry-helper is distributed in the hope that it will be useful,
+'but WITHOUT ANY WARRANTY; without even the implied warranty of
+'MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+'GNU General Public License for more details.
+'
+'You should have received a copy of the GNU General Public License
+'along with hsp_registry-helper.  If not, see <http://www.gnu.org/licenses/>.
+
+
+
+
+' Microsoft.Win32 is used for registry stuff.
+Imports Microsoft.Win32
+
+Public Class regkeyvalue_Apply
+    ' If the user chooses to /undo the Registry key value,
+    ' delete the proper key value if it exists.
+
+    ' I'm using a solution based on this thread:
+    ' https://social.msdn.microsoft.com/Forums/en-US/7272f987-bfb5-4bac-a72c-dfde5745832f/how-to-use-add-read-change-delete-registry-keys-with-vbnet?forum=Vsexpressvb
+
+    Friend Shared Sub runDeletion()
+        MessageBox.Show("/apply was chosen.")
+        Dim tempVal As String = My.Computer.Registry.GetValue("HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer", "SettingsPageVisibility", Nothing)
+
+        ' First see if there's a key value to delete.
+        If tempVal IsNot Nothing Then
+            ' Next, if the user is admin, delete the key value. Using a try/catch because I don't know
+            ' how to do it properly. Can't find any examples in VB.
+
+            ' Now we can delete the key value.
+            ' Code from:
+            ' https://social.msdn.microsoft.com/Forums/en-US/7272f987-bfb5-4bac-a72c-dfde5745832f/how-to-use-add-read-change-delete-registry-keys-with-vbnet?forum=Vsexpressvb
+
+            Try
+                Dim deleteFrom As RegistryKey = My.Computer.Registry.LocalMachine.OpenSubKey("SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer", True)
+                deleteFrom.DeleteValue("SettingsPageVisibility")
+            Catch ex As Security.SecurityException
+                ' Tell the user if they're not elevated.
+
+                MessageBox.Show("The Registry key value cannot be deleted because the app isn't running as Administrator. Please elevate and try again.")
+            End Try
+        End If
+    End Sub
+End Class

--- a/hsp_registry-helper/Registry Key Manipulation Stuff/regkeyvalue_Apply.vb
+++ b/hsp_registry-helper/Registry Key Manipulation Stuff/regkeyvalue_Apply.vb
@@ -57,7 +57,7 @@ Public Class regkeyvalue_Apply
             Catch ex As Security.SecurityException
                 ' Tell the user if they're not elevated.
 
-                MessageBox.Show("The Registry key value cannot be deleted because the app isn't running as Administrator. Please elevate and try again.")
+                MessageBox.Show("The Registry key value cannot be edited because the app isn't running as Administrator. Please elevate and try again.")
             End Try
         End If
     End Sub

--- a/hsp_registry-helper/Registry Key Manipulation Stuff/regkeyvalue_Apply.vb
+++ b/hsp_registry-helper/Registry Key Manipulation Stuff/regkeyvalue_Apply.vb
@@ -47,7 +47,7 @@ Public Class regkeyvalue_Apply
             ' Next, if the user is admin, edit the key value. Using a try/catch because I don't know
             ' how to do it properly. Can't find any examples in VB.
 
-            ' Now we can edit the key value.
+            ' Now we can edit the key value with the user's choice.
             ' Code from:
             ' https://social.msdn.microsoft.com/Forums/en-US/7272f987-bfb5-4bac-a72c-dfde5745832f/how-to-use-add-read-change-delete-registry-keys-with-vbnet?forum=Vsexpressvb
 
@@ -65,6 +65,24 @@ Public Class regkeyvalue_Apply
         Else
             ' Otherwise, just make a new Registry key value
             ' and modify it.
+
+            ' If the user is admin, make a new key value. Using a try/catch because I don't know
+            ' how to do it properly. Can't find any examples in VB.
+
+            ' Now we can make a new key value with the user's choice.
+            ' Code from:
+            ' https://social.msdn.microsoft.com/Forums/en-US/7272f987-bfb5-4bac-a72c-dfde5745832f/how-to-use-add-read-change-delete-registry-keys-with-vbnet?forum=Vsexpressvb
+
+            Try
+                Dim editFrom As RegistryKey = My.Computer.Registry.LocalMachine.OpenSubKey("SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer", True)
+                ' Now edit the Registry key value.
+                editFrom.SetValue("SettingsPageVisibility", fullKeyValue)
+                editFrom.Close()
+            Catch ex As Security.SecurityException
+                ' Tell the user if they're not elevated.
+
+                MessageBox.Show("The Registry key value cannot be edited because the app isn't running as Administrator. Please elevate and try again.")
+            End Try
 
         End If
     End Sub

--- a/hsp_registry-helper/Registry Key Manipulation Stuff/regkeyvalue_Apply.vb
+++ b/hsp_registry-helper/Registry Key Manipulation Stuff/regkeyvalue_Apply.vb
@@ -40,7 +40,7 @@ Public Class regkeyvalue_Apply
 
     Friend Shared Sub runApplying()
         MessageBox.Show("/apply was chosen.")
-        Dim tempVal As String = My.Computer.Registry.GetValue("HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer", "SettingsPageVisibility", Nothing)
+        Dim tempVal As String = My.Computer.Registry.GetValue("HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer", "SettingsPageVisibility", Nothing).ToString
 
         ' First see if there's a key value to edit.
         If tempVal IsNot Nothing Then

--- a/hsp_registry-helper/Registry Key Manipulation Stuff/regkeyvalue_Apply.vb
+++ b/hsp_registry-helper/Registry Key Manipulation Stuff/regkeyvalue_Apply.vb
@@ -40,50 +40,25 @@ Public Class regkeyvalue_Apply
 
     Friend Shared Sub runApplying()
         MessageBox.Show("/apply was chosen.")
-        Dim tempVal As Object = My.Computer.Registry.GetValue("HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer", "SettingsPageVisibility", Nothing)
 
-        ' First see if there's a key value to edit.
-        If tempVal IsNot Nothing Then
-            ' Next, if the user is admin, edit the key value. Using a try/catch because I don't know
-            ' how to do it properly. Can't find any examples in VB.
+        ' If the user is admin, edit the key value. Using a try/catch because I don't know
+        ' how to do it properly. Can't find any examples in VB.
 
-            ' Now we can edit the key value with the user's choice.
-            ' Code from:
-            ' https://social.msdn.microsoft.com/Forums/en-US/7272f987-bfb5-4bac-a72c-dfde5745832f/how-to-use-add-read-change-delete-registry-keys-with-vbnet?forum=Vsexpressvb
+        ' Now we can edit the key value with the user's choice.
+        ' Code from:
+        ' https://social.msdn.microsoft.com/Forums/en-US/7272f987-bfb5-4bac-a72c-dfde5745832f/how-to-use-add-read-change-delete-registry-keys-with-vbnet?forum=Vsexpressvb
 
-            Try
-                Dim editFrom As RegistryKey = My.Computer.Registry.LocalMachine.OpenSubKey("SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer", True)
-                ' Now edit the Registry key value.
-                editFrom.SetValue("SettingsPageVisibility", fullKeyValue)
-                editFrom.Close()
-            Catch ex As Security.SecurityException
-                ' Tell the user if they're not elevated.
+        Try
+            Dim editFrom As RegistryKey = My.Computer.Registry.LocalMachine.OpenSubKey("SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer", True)
+            ' Now edit the Registry key value.
+            ' This also creates a new Registry key value if there
+            ' isn't one there already.
+            editFrom.SetValue("SettingsPageVisibility", fullKeyValue)
+            editFrom.Close()
+        Catch ex As Security.SecurityException
+            ' Tell the user if they're not elevated.
 
-                MessageBox.Show("The Registry key value cannot be edited because the app isn't running as Administrator. Please elevate and try again.")
-            End Try
-
-        Else
-            ' Otherwise, just make a new Registry key value
-            ' and modify it.
-
-            ' If the user is admin, make a new key value. Using a try/catch because I don't know
-            ' how to do it properly. Can't find any examples in VB.
-
-            ' Now we can make a new key value with the user's choice.
-            ' Code from:
-            ' https://social.msdn.microsoft.com/Forums/en-US/7272f987-bfb5-4bac-a72c-dfde5745832f/how-to-use-add-read-change-delete-registry-keys-with-vbnet?forum=Vsexpressvb
-
-            Try
-                Dim editFrom As RegistryKey = My.Computer.Registry.LocalMachine.OpenSubKey("SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer", True)
-                ' Now edit the Registry key value.
-                editFrom.SetValue("SettingsPageVisibility", fullKeyValue)
-                editFrom.Close()
-            Catch ex As Security.SecurityException
-                ' Tell the user if they're not elevated.
-
-                MessageBox.Show("The Registry key value cannot be edited because the app isn't running as Administrator. Please elevate and try again.")
-            End Try
-
-        End If
+            MessageBox.Show("The Registry key value cannot be edited because the app isn't running as Administrator. Please elevate and try again.")
+        End Try
     End Sub
 End Class

--- a/hsp_registry-helper/Registry Key Manipulation Stuff/regkeyvalue_Apply.vb
+++ b/hsp_registry-helper/Registry Key Manipulation Stuff/regkeyvalue_Apply.vb
@@ -40,7 +40,7 @@ Public Class regkeyvalue_Apply
 
     Friend Shared Sub runApplying()
         MessageBox.Show("/apply was chosen.")
-        Dim tempVal As String = My.Computer.Registry.GetValue("HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer", "SettingsPageVisibility", Nothing).ToString
+        Dim tempVal As Object = My.Computer.Registry.GetValue("HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer", "SettingsPageVisibility", Nothing)
 
         ' First see if there's a key value to edit.
         If tempVal IsNot Nothing Then

--- a/hsp_registry-helper/Registry Key Manipulation Stuff/regkeyvalue_Apply.vb
+++ b/hsp_registry-helper/Registry Key Manipulation Stuff/regkeyvalue_Apply.vb
@@ -42,12 +42,12 @@ Public Class regkeyvalue_Apply
         MessageBox.Show("/apply was chosen.")
         Dim tempVal As String = My.Computer.Registry.GetValue("HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer", "SettingsPageVisibility", Nothing)
 
-        ' First see if there's a key value to delete.
+        ' First see if there's a key value to edit.
         If tempVal IsNot Nothing Then
-            ' Next, if the user is admin, delete the key value. Using a try/catch because I don't know
+            ' Next, if the user is admin, edit the key value. Using a try/catch because I don't know
             ' how to do it properly. Can't find any examples in VB.
 
-            ' Now we can delete the key value.
+            ' Now we can edit the key value.
             ' Code from:
             ' https://social.msdn.microsoft.com/Forums/en-US/7272f987-bfb5-4bac-a72c-dfde5745832f/how-to-use-add-read-change-delete-registry-keys-with-vbnet?forum=Vsexpressvb
 

--- a/hsp_registry-helper/Registry Key Manipulation Stuff/regkeyvalue_Apply.vb
+++ b/hsp_registry-helper/Registry Key Manipulation Stuff/regkeyvalue_Apply.vb
@@ -58,7 +58,7 @@ Public Class regkeyvalue_Apply
         Catch ex As Security.SecurityException
             ' Tell the user if they're not elevated.
 
-            MessageBox.Show("The Registry key value cannot be edited because the app isn't running as Administrator. Please elevate and try again.")
+            MessageBox.Show("The Registry key value cannot be edited because the app isn't running as Administrator. Please elevate and try again.", "Apply changes")
         End Try
     End Sub
 End Class

--- a/hsp_registry-helper/Registry Key Manipulation Stuff/regkeyvalue_Apply.vb
+++ b/hsp_registry-helper/Registry Key Manipulation Stuff/regkeyvalue_Apply.vb
@@ -61,6 +61,11 @@ Public Class regkeyvalue_Apply
 
                 MessageBox.Show("The Registry key value cannot be edited because the app isn't running as Administrator. Please elevate and try again.")
             End Try
+
+        Else
+            ' Otherwise, just make a new Registry key value
+            ' and modify it.
+
         End If
     End Sub
 End Class

--- a/hsp_registry-helper/Registry Key Manipulation Stuff/regkeyvalue_Apply.vb
+++ b/hsp_registry-helper/Registry Key Manipulation Stuff/regkeyvalue_Apply.vb
@@ -32,13 +32,13 @@
 Imports Microsoft.Win32
 
 Public Class regkeyvalue_Apply
-    ' If the user chooses to /undo the Registry key value,
-    ' delete the proper key value if it exists.
+    ' If the user chooses to /apply the Registry key value,
+    ' create or edit the proper key value if it exists.
 
     ' I'm using a solution based on this thread:
     ' https://social.msdn.microsoft.com/Forums/en-US/7272f987-bfb5-4bac-a72c-dfde5745832f/how-to-use-add-read-change-delete-registry-keys-with-vbnet?forum=Vsexpressvb
 
-    Friend Shared Sub runDeletion()
+    Friend Shared Sub runApplying()
         MessageBox.Show("/apply was chosen.")
         Dim tempVal As String = My.Computer.Registry.GetValue("HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer", "SettingsPageVisibility", Nothing)
 

--- a/hsp_registry-helper/Registry Key Manipulation Stuff/regkeyvalue_Undo.vb
+++ b/hsp_registry-helper/Registry Key Manipulation Stuff/regkeyvalue_Undo.vb
@@ -40,7 +40,7 @@ Public Class regkeyvalue_Undo
 
     Friend Shared Sub runDeletion()
         MessageBox.Show("/undo was chosen.")
-        Dim tempVal As String = My.Computer.Registry.GetValue("HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer", "SettingsPageVisibility", Nothing)
+        Dim tempVal As String = My.Computer.Registry.GetValue("HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer", "SettingsPageVisibility", Nothing).ToString
 
         ' First see if there's a key value to delete.
         If tempVal IsNot Nothing Then

--- a/hsp_registry-helper/Registry Key Manipulation Stuff/regkeyvalue_Undo.vb
+++ b/hsp_registry-helper/Registry Key Manipulation Stuff/regkeyvalue_Undo.vb
@@ -57,8 +57,7 @@ Public Class regkeyvalue_Undo
                 deleteFrom.DeleteValue("SettingsPageVisibility")
             Catch ex As Security.SecurityException
                 ' Tell the user if they're not elevated.
-
-                MessageBox.Show("The Registry key value cannot be deleted because the app isn't running as Administrator. Please elevate and try again.")
+                MessageBox.Show("The Registry key value cannot be deleted because the app isn't running as Administrator. Please elevate and try again.", "Undo all changes")
             End Try
 
         Else

--- a/hsp_registry-helper/Registry Key Manipulation Stuff/regkeyvalue_Undo.vb
+++ b/hsp_registry-helper/Registry Key Manipulation Stuff/regkeyvalue_Undo.vb
@@ -61,6 +61,11 @@ Public Class regkeyvalue_Undo
                 MessageBox.Show("The Registry key value cannot be deleted because the app isn't running as Administrator. Please elevate and try again.")
             End Try
 
+        Else
+            ' If there's no Registry key value to delete,
+            ' tell the user.
+            MessageBox.Show("There's no Registry key value to delete.", "Undo all changes")
+
         End If
     End Sub
 End Class

--- a/hsp_registry-helper/Registry Key Manipulation Stuff/regkeyvalue_Undo.vb
+++ b/hsp_registry-helper/Registry Key Manipulation Stuff/regkeyvalue_Undo.vb
@@ -40,7 +40,7 @@ Public Class regkeyvalue_Undo
 
     Friend Shared Sub runDeletion()
         MessageBox.Show("/undo was chosen.")
-        Dim tempVal As Object = My.Computer.Registry.GetValue("HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer", "SettingsPageVisibility", Nothing).ToString
+        Dim tempVal As Object = My.Computer.Registry.GetValue("HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer", "SettingsPageVisibility", Nothing)
 
         ' First see if there's a key value to delete.
         If tempVal IsNot Nothing Then
@@ -60,6 +60,7 @@ Public Class regkeyvalue_Undo
 
                 MessageBox.Show("The Registry key value cannot be deleted because the app isn't running as Administrator. Please elevate and try again.")
             End Try
+
         End If
     End Sub
 End Class

--- a/hsp_registry-helper/Registry Key Manipulation Stuff/regkeyvalue_Undo.vb
+++ b/hsp_registry-helper/Registry Key Manipulation Stuff/regkeyvalue_Undo.vb
@@ -40,7 +40,7 @@ Public Class regkeyvalue_Undo
 
     Friend Shared Sub runDeletion()
         MessageBox.Show("/undo was chosen.")
-        Dim tempVal As String = My.Computer.Registry.GetValue("HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer", "SettingsPageVisibility", Nothing).ToString
+        Dim tempVal As Object = My.Computer.Registry.GetValue("HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer", "SettingsPageVisibility", Nothing).ToString
 
         ' First see if there's a key value to delete.
         If tempVal IsNot Nothing Then

--- a/hsp_registry-helper/Registry Key Manipulation Stuff/regkeyvalue_Undo.vb
+++ b/hsp_registry-helper/Registry Key Manipulation Stuff/regkeyvalue_Undo.vb
@@ -53,6 +53,7 @@ Public Class regkeyvalue_Undo
 
             Try
                 Dim deleteFrom As RegistryKey = My.Computer.Registry.LocalMachine.OpenSubKey("SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer", True)
+                ' Now delete the key value.
                 deleteFrom.DeleteValue("SettingsPageVisibility")
             Catch ex As Security.SecurityException
                 ' Tell the user if they're not elevated.

--- a/hsp_registry-helper/Registry Key Manipulation Stuff/regkeyvalue_Verify.vb
+++ b/hsp_registry-helper/Registry Key Manipulation Stuff/regkeyvalue_Verify.vb
@@ -37,7 +37,10 @@ Public Class regkeyvalue_Verify
 
     Public Shared Sub runVerification()
 
-        Dim tempVal As String = My.Computer.Registry.GetValue("HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer", "SettingsPageVisibility", Nothing).ToString
+
+        Dim tempVal As Object = My.Computer.Registry.GetValue("HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer", "SettingsPageVisibility", Nothing)
+
+
 
         If tempVal Is Nothing Then
             ' If the registry key value doesn't exist, tell the user.
@@ -45,7 +48,7 @@ Public Class regkeyvalue_Verify
 
         Else
             ' If the registry key value does exist, tell the user what it is.
-            MessageBox.Show("Registry key value exists." & vbCrLf & vbCrLf & vbCrLf & "Data:" & vbCrLf & vbCrLf & tempVal, "Verify key value")
+            MessageBox.Show("Registry key value exists." & vbCrLf & vbCrLf & vbCrLf & "Data:" & vbCrLf & vbCrLf & tempVal.ToString, "Verify key value")
 
         End If
 

--- a/hsp_registry-helper/Registry Key Manipulation Stuff/regkeyvalue_Verify.vb
+++ b/hsp_registry-helper/Registry Key Manipulation Stuff/regkeyvalue_Verify.vb
@@ -37,7 +37,7 @@ Public Class regkeyvalue_Verify
 
     Public Shared Sub runVerification()
 
-        Dim tempVal As String = My.Computer.Registry.GetValue("HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer", "SettingsPageVisibility", Nothing)
+        Dim tempVal As String = My.Computer.Registry.GetValue("HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer", "SettingsPageVisibility", Nothing).ToString
 
         If tempVal Is Nothing Then
             ' If the registry key value doesn't exist, tell the user.

--- a/hsp_registry-helper/Registry Key Manipulation Stuff/regkeyvalue_Verify.vb
+++ b/hsp_registry-helper/Registry Key Manipulation Stuff/regkeyvalue_Verify.vb
@@ -40,8 +40,6 @@ Public Class regkeyvalue_Verify
 
         Dim tempVal As Object = My.Computer.Registry.GetValue("HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer", "SettingsPageVisibility", Nothing)
 
-
-
         If tempVal Is Nothing Then
             ' If the registry key value doesn't exist, tell the user.
             MessageBox.Show("Registry key value does not exist.", "Verify key value")

--- a/hsp_registry-helper/argsOutput.vb
+++ b/hsp_registry-helper/argsOutput.vb
@@ -76,7 +76,9 @@ Public Class argsOutput
         If actionToTake = "/verify" Then
             regkeyvalue_Verify.runVerification()
         ElseIf actionToTake = "/undo" Then
-            regkeyvalue_Undo.runDeletion
+            regkeyvalue_Undo.runDeletion()
+        ElseIf actionToTake = "/apply" Then
+            regkeyvalue_Apply.runApplying()
         End If
     End Sub
 End Class

--- a/hsp_registry-helper/hsp_registry-helper.vbproj
+++ b/hsp_registry-helper/hsp_registry-helper.vbproj
@@ -38,8 +38,10 @@
     <DefineTrace>true</DefineTrace>
     <OutputPath>..\HideSettingsPages\bin\Debug\</OutputPath>
     <DocumentationFile>hsp_registry-helper.xml</DocumentationFile>
-    <NoWarn>42016,41999,42017,42018,42019,42032,42036,42020,42021,42022</NoWarn>
+    <NoWarn>
+    </NoWarn>
     <UseVSHostingProcess>false</UseVSHostingProcess>
+    <WarningsAsErrors>41999,42016,42017,42018,42019,42020,42021,42022,42032,42036</WarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -49,7 +51,9 @@
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
     <DocumentationFile>hsp_registry-helper.xml</DocumentationFile>
-    <NoWarn>42016,41999,42017,42018,42019,42032,42036,42020,42021,42022</NoWarn>
+    <NoWarn>
+    </NoWarn>
+    <WarningsAsErrors>41999,42016,42017,42018,42019,42020,42021,42022,42032,42036</WarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup>
     <OptionExplicit>On</OptionExplicit>
@@ -58,7 +62,7 @@
     <OptionCompare>Binary</OptionCompare>
   </PropertyGroup>
   <PropertyGroup>
-    <OptionStrict>Off</OptionStrict>
+    <OptionStrict>On</OptionStrict>
   </PropertyGroup>
   <PropertyGroup>
     <OptionInfer>On</OptionInfer>

--- a/hsp_registry-helper/hsp_registry-helper.vbproj
+++ b/hsp_registry-helper/hsp_registry-helper.vbproj
@@ -107,6 +107,7 @@
       <DesignTimeSharedInput>True</DesignTimeSharedInput>
     </Compile>
     <Compile Include="argsOutput.vb" />
+    <Compile Include="Registry Key Manipulation Stuff\regkeyvalue_Apply.vb" />
     <Compile Include="Registry Key Manipulation Stuff\regkeyvalue_Undo.vb" />
     <Compile Include="Registry Key Manipulation Stuff\regkeyvalue_Verify.vb" />
   </ItemGroup>


### PR DESCRIPTION
By doing this, HideSettingsPages can be used to select pages in the Settings app to hide (or show only) and hsp_registry-helper will apply them in the proper spot. 

Changes:

- Turned on Option Strict. 

- Fixed some issues exposed by Option Strict. 

- Added a Try...Catch for anytime the user chooses not to apply or undo the Registry key value. Otherwise, there would be an error message when the user clicks "No" in the UAC dialog.

- Added titlebar text to some messageboxes.