### PR TITLE
Allow /help and /? args to display help info text.

### DIFF
--- a/hsp_registry-helper/argsOutput.vb
+++ b/hsp_registry-helper/argsOutput.vb
@@ -55,7 +55,7 @@ Public Class argsOutput
             & vbCrLf & vbTab & "/help" & vbTab & vbTab & "Display this help text." _
             & vbCrLf & vbTab & "/?" & vbTab & vbTab & "Display this help text.")
         Console.WriteLine("")
-        Console.WriteLine(vbTab & "<key value> is the Registry key to apply to the system in the form of <hide or showonly>:<page>;<more pages>")
+        Console.WriteLine(vbTab & "<key value> is the Registry key value to apply to the system in the form of" & vbCrLf & vbTab & vbTab & "<hide or showonly>:<page>;<more pages>")
         Console.WriteLine("")
         Console.WriteLine(vbTab & "A <key value> is only required if using ""/apply"" as an <action>.")
         Console.WriteLine("")

--- a/hsp_registry-helper/argsOutput.vb
+++ b/hsp_registry-helper/argsOutput.vb
@@ -51,7 +51,9 @@ Public Class argsOutput
         Console.WriteLine(vbTab & "Action:" & vbTab & vbTab & "Description:" _
             & vbCrLf & vbTab & "/apply" & vbTab & vbTab & "Apply Registry key value. Requires admin permissions." _
             & vbCrLf & vbTab & "/undo" & vbTab & vbTab & "Remove Registry key value. Requires admin permissions." _
-            & vbCrLf & vbTab & "/verify" & vbTab & vbTab & "Show the current Registry key value if it exists.")
+            & vbCrLf & vbTab & "/verify" & vbTab & vbTab & "Show the current Registry key value if it exists." _
+            & vbCrLf & vbTab & "/help" & vbTab & vbTab & "Display this text." _
+            & vbCrLf & vbTab & "/?" & vbTab & vbTab & "Display this text.")
         Console.WriteLine("")
         Console.WriteLine(vbTab & "<key value> is the Registry key to apply to the system in the form of <hide or showonly>:<page>;<more pages>")
         Console.WriteLine("")
@@ -63,9 +65,17 @@ Public Class argsOutput
         Console.WriteLine(vbTab & "hsp_registry-helper.exe /apply showonly:display;about")
         Console.WriteLine(vbTab & "hsp_registry-helper.exe /undo")
         Console.WriteLine(vbTab & "hsp_registry-helper.exe /verify")
+        Console.WriteLine(vbTab & "hsp_registry-helper.exe /help")
+        Console.WriteLine(vbTab & "hsp_registry-helper.exe /?")
+
         ' Only shows an error message if showMessageBox is set to True.
         If showMessageBox = True Then
             MessageBox.Show(message, messageTitle, MessageBoxButtons.OK, MessageBoxIcon.Error)
+            ' Otherwise, if no messagebox will be shown, ask the user to push any key to continue.
+        ElseIf showMessageBox = False Then
+            Console.WriteLine("")
+            Console.WriteLine("Press Enter to continue...")
+            Console.ReadLine()
         End If
     End Sub
 

--- a/hsp_registry-helper/argsOutput.vb
+++ b/hsp_registry-helper/argsOutput.vb
@@ -81,6 +81,8 @@ Public Class argsOutput
             regkeyvalue_Undo.runDeletion()
         ElseIf actionToTake = "/apply" Then
             regkeyvalue_Apply.runApplying()
+        ElseIf actionToTake = "/help" Or actionToTake = "/?" Then
+            noOrInvalidCommandLineArgs("", "Help info", False)
         Else
             ' If the argument isn't valid,
             ' tell the user and display

--- a/hsp_registry-helper/argsOutput.vb
+++ b/hsp_registry-helper/argsOutput.vb
@@ -52,8 +52,8 @@ Public Class argsOutput
             & vbCrLf & vbTab & "/apply" & vbTab & vbTab & "Apply Registry key value. Requires admin permissions." _
             & vbCrLf & vbTab & "/undo" & vbTab & vbTab & "Remove Registry key value. Requires admin permissions." _
             & vbCrLf & vbTab & "/verify" & vbTab & vbTab & "Show the current Registry key value if it exists." _
-            & vbCrLf & vbTab & "/help" & vbTab & vbTab & "Display this text." _
-            & vbCrLf & vbTab & "/?" & vbTab & vbTab & "Display this text.")
+            & vbCrLf & vbTab & "/help" & vbTab & vbTab & "Display this help text." _
+            & vbCrLf & vbTab & "/?" & vbTab & vbTab & "Display this help text.")
         Console.WriteLine("")
         Console.WriteLine(vbTab & "<key value> is the Registry key to apply to the system in the form of <hide or showonly>:<page>;<more pages>")
         Console.WriteLine("")
@@ -71,7 +71,7 @@ Public Class argsOutput
         ' Only shows an error message if showMessageBox is set to True.
         If showMessageBox = True Then
             MessageBox.Show(message, messageTitle, MessageBoxButtons.OK, MessageBoxIcon.Error)
-            ' Otherwise, if no messagebox will be shown, ask the user to push any key to continue.
+            ' Otherwise, if no messagebox will be shown, ask the user to push Enter to continue.
         ElseIf showMessageBox = False Then
             Console.WriteLine("")
             Console.WriteLine("Press Enter to continue...")

--- a/hsp_registry-helper/argsOutput.vb
+++ b/hsp_registry-helper/argsOutput.vb
@@ -28,7 +28,7 @@
 
 
 Public Class argsOutput
-    Friend Shared Sub noOrInvalidCommandLineArgs(message As String, messageTitle As String)
+    Friend Shared Sub noOrInvalidCommandLineArgs(message As String, messageTitle As String, showMessageBox As Boolean)
         ' Update titlebar to tell the user there's no arguments passed.
         Console.Title = titlebarText & ": " & messageTitle & "."
         ' Show the user app info including title, version, copyright, and license.
@@ -63,7 +63,10 @@ Public Class argsOutput
         Console.WriteLine(vbTab & "hsp_registry-helper.exe /apply showonly:display;about")
         Console.WriteLine(vbTab & "hsp_registry-helper.exe /undo")
         Console.WriteLine(vbTab & "hsp_registry-helper.exe /verify")
-        MessageBox.Show(message, messageTitle, MessageBoxButtons.OK, MessageBoxIcon.Error)
+        ' Only shows an error message if showMessageBox is set to True.
+        If showMessageBox = True Then
+            MessageBox.Show(message, messageTitle, MessageBoxButtons.OK, MessageBoxIcon.Error)
+        End If
     End Sub
 
     Friend Shared Sub passCommandLineArgs()
@@ -82,7 +85,7 @@ Public Class argsOutput
             ' If the argument isn't valid,
             ' tell the user and display
             ' the valid args.
-            noOrInvalidCommandLineArgs("Invalid commandline argument: " & actionToTake, "Invalid commandline argument")
+            noOrInvalidCommandLineArgs("Invalid commandline argument: " & actionToTake, "Invalid commandline argument", True)
         End If
     End Sub
 End Class

--- a/hsp_registry-helper/hsp_registry_helper_main.vb
+++ b/hsp_registry-helper/hsp_registry_helper_main.vb
@@ -49,12 +49,12 @@ Public Module hsp_registry_helper_main
         If sArgs.Length = 0 Then
             'If there are no arguments, print app info and 
             ' tell the user what arguments are accepted.
-            argsOutput.noOrInvalidCommandLineArgs("No arguments passed.", "No arguments passed")
+            argsOutput.noOrInvalidCommandLineArgs("No arguments passed.", "No arguments passed", True)
 
         ElseIf sArgs.Length = 1 Then
             ' If there's only one argument and /apply is being used, complain.
             If sArgs(0) = "/apply" Then
-                argsOutput.noOrInvalidCommandLineArgs("<key value> must be available if trying to use /apply as <action>.", "Argument missing")
+                argsOutput.noOrInvalidCommandLineArgs("<key value> must be available if trying to use /apply as <action>.", "Argument missing", True)
 
             ElseIf Not sArgs(0) = "/apply" Then
                 ' If the argument isn't /apply, don't complain and set the first arg correctly.


### PR DESCRIPTION
These args allow the user to directly display the help info text that usually is only shown if incorrect args are used without displaying an error message.